### PR TITLE
Bug fix and couple minor improvements

### DIFF
--- a/gen_reads.py
+++ b/gen_reads.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env source
+#!/usr/bin/env python3
 # encoding: utf-8
 """ ////////////////////////////////////////////////////////////////////////////////
    ///                                                                          ///
@@ -405,8 +405,13 @@ def main(raw_args=None):
     # keep track of the number of reads we've sampled, for read-names
     read_name_count = 1
     unmapped_records = []
+    skip_chromosomes = off_target_scalar == 0.0 or off_target_discard
 
     for chrom in range(len(ref_index)):
+        chrom_name = ref_index[chrom][0]
+        if input_regions and chrom_name not in input_regions and skip_chromosomes:
+            # print('Skipping {}'.format(chrom_name))
+            continue
 
         # read in reference sequence and notate blocks of Ns
         (ref_sequence, n_regions) = read_ref(reference, ref_index[chrom], n_handling)

--- a/source/output_file_writer.py
+++ b/source/output_file_writer.py
@@ -183,8 +183,9 @@ class OutputFileWriter:
         if read2 is not None and orientation is True:
             (read2, quality2) = (read2.reverse_complement(), qual2[::-1])
         elif read2 is not None and orientation is False:
+            prev_read1 = read1
             (read1, quality1) = (read2.reverse_complement(), qual2[::-1])
-            (read2, quality2) = (read1, qual1)
+            (read2, quality2) = (prev_read1, qual1)
 
         if self.fasta_instead:
             self.fq1_buffer.append('>' + read_name + '/1\n' + str(read1) + '\n')

--- a/source/ref_func.py
+++ b/source/ref_func.py
@@ -132,10 +132,10 @@ def read_ref(ref_path, ref_inds_i, n_handling, n_unknowns=True, quiet=False):
         for region in n_atlas:
             n_info['all'].extend(region)
             if region[1] - region[0] <= n_handling[1]:
+                temp = my_dat.tomutable()
                 for i in range(region[0], region[1]):
-                    temp = my_dat.tomutable()
                     temp[i] = random.choice(ALLOWED_NUCL)
-                    my_dat = temp.toseq()
+                my_dat = temp.toseq()
             else:
                 n_info['big'].extend(region)
     elif n_handling[0] == 'allChr' and n_handling[2] in OK_CHR_ORD:


### PR DESCRIPTION
- Bug fix in output_file_writer.py: in some cases read1 and read2 are identical in output fastq files (and different in output BAM file).
- Skip chromosomes if they are not in input regions and `-to 0` or `--discard-offtarget`.
- `ref_func.py`: in `read_ref` if `n_handling` is `random` - slightly speed up sequence randomization.
